### PR TITLE
Remove a dead link to non-existent docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ An example of how to call each generative virtual screening step is located in `
 
 ### Additional Documentation
 
-You can try this blueprint and find its Model Card on [build.nvidia.com](https://build.nvidia.com/nvidia/generative-virtual-screening-for-drug-discovery)
+You can try this Blueprint and find its Blueprint Card on [build.nvidia.com](https://build.nvidia.com/nvidia/generative-virtual-screening-for-drug-discovery)
 

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ An example of how to call each generative virtual screening step is located in `
 
 ### Additional Documentation
 
-Additional documentation can be found on [docs.nvidia.com](https://nim-docs-staging.s3.us-west-1.amazonaws.com/bionemo-caddvs/main/overview.html).
+You can try this blueprint and find its Model Card on [build.nvidia.com](https://build.nvidia.com/nvidia/generative-virtual-screening-for-drug-discovery)
 


### PR DESCRIPTION
Fixes a link in the README that pointed to a non-accessible location. I have updated this to now point to the live Blueprint example and model card at build.nvidia.com.